### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ TLDR:
 - Yes they are anonymous identified (it is NOT tied any kind of Facebook data). 
 - No, no analytics can read anything on the messenger webpage.
 
-Yes there are analytics services in the code. It may seem that this may comprimise the privacy of your facebook messenger data. However, if you look at how the code is written, the analytics are in your background scripts. This is separated and indepdendent from the content scripts portion which is the part that actually interacts the Facebook Messenger page. Therefore, the analytics cannot see any of the Facebook data.
+Yes there are analytics services in the code. It may seem that this may compromise the privacy of your facebook messenger data. However, if you look at how the code is written, the analytics are in your background scripts. This is separated and indepdendent from the content scripts portion which is the part that actually interacts the Facebook Messenger page. Therefore, the analytics cannot see any of the Facebook data.
 
 [![Mobile Analytics](http://cdn.mxpnl.com/site_media/images/partner/badge_light.png)](https://mixpanel.com/f/partner)


### PR DESCRIPTION
@jonleung, I've corrected a typographical error in the documentation of the [distraction-free-facebook-messenger](https://github.com/jonleung/distraction-free-facebook-messenger) project. Specifically, I've changed comprimise to compromise. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
